### PR TITLE
fixes issue of @tsparticles/slim The Following dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ Official [tsParticles](https://github.com/tsparticles/tsparticles) ReactJS compo
 ## Installation
 
 ```shell
-npm install @tsparticles/react
+npm install tsparticles @tsparticles/react
 ```
 
 or
 
 ```shell
-yarn add @tsparticles/react
+yarn add tsparticles @tsparticles/react
 ```
 
 ### TypeScript Installation
 
 ```shell
-npm install @tsparticles/react @tsparticles/engine
+npm install tsparticles @tsparticles/react @tsparticles/engine
 ```
 
 or
 
 ```shell
-yarn add @tsparticles/react @tsparticles/engine
+yarn add tsparticles @tsparticles/react @tsparticles/engine
 ```
 
 [@tsparticles/engine](https://npmjs.com/package/@tsparticles/engine) is the core package for [tsParticles](https://particles.js.org), it contains useful types like `ISourceOptions`, `Engine` or `Container`.


### PR DESCRIPTION
## What does this PR do ?
fixes: #120 
## Type of change

#### Before change
![image](https://github.com/user-attachments/assets/d015884e-3c98-45a8-8234-2b998b7fbac7)
#### After change
![image](https://github.com/user-attachments/assets/52532365-309e-436c-a78a-f874f1dd1bef)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated installation instructions for the `@tsparticles/react` package to include `tsparticles` as a required dependency for both npm and yarn.
	- Revised TypeScript installation commands to reflect the necessity of the `tsparticles` package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->