### PR TITLE
fix: forward style and other props to wrapper div

### DIFF
--- a/components/react/lib/Particles.tsx
+++ b/components/react/lib/Particles.tsx
@@ -12,16 +12,17 @@ const Particles: FC<IParticlesProps> = (props) => {
       .load({ id, url: props.url, options: props.options })
       .then((c) => {
         container = c;
-
         props.particlesLoaded?.(c);
       });
 
     return () => {
       container?.destroy();
     };
-  }, [id, props, props.url, props.options]);
+  }, [id, props.url, props.options]);
 
-  return <div id={id} className={props.className}></div>;
+  const { id: _ignored, particlesLoaded, options, url, ...rest } = props;
+
+  return <div id={id} {...rest} />;
 };
 
 export default Particles;


### PR DESCRIPTION
The style prop was not being forwarded to the wrapper div,
causing it to have no effect.

This change forwards the style and other remaining props
to the wrapper div so they work correctly.

Fixes #119.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized component dependency tracking and prop handling in the Particles component for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->